### PR TITLE
refactor: use intent factory methods for Login/Landing

### DIFF
--- a/app/src/main/java/edu/csumb/cst338/otterbots/rockpaperscissors/LandingActivity.java
+++ b/app/src/main/java/edu/csumb/cst338/otterbots/rockpaperscissors/LandingActivity.java
@@ -3,6 +3,7 @@ package edu.csumb.cst338.otterbots.rockpaperscissors;
 import static edu.csumb.cst338.otterbots.rockpaperscissors.LoginActivity.EXTRA_IS_ADMIN;
 import static edu.csumb.cst338.otterbots.rockpaperscissors.LoginActivity.EXTRA_USERNAME;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.widget.Toast;
@@ -13,6 +14,13 @@ import edu.csumb.cst338.otterbots.rockpaperscissors.databinding.ActivityLandingA
 import edu.csumb.cst338.otterbots.rockpaperscissors.databinding.ActivityLandingUserBinding;
 
 public class LandingActivity extends AppCompatActivity {
+
+    public static Intent createIntent(Context context, String userName, boolean isAdmin) {
+        Intent intent = new Intent(context, LandingActivity.class);
+        intent.putExtra(EXTRA_USERNAME, userName);
+        intent.putExtra(EXTRA_IS_ADMIN, isAdmin);
+        return intent;
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -90,10 +98,7 @@ public class LandingActivity extends AppCompatActivity {
     }
 
     private void logout() {
-        Intent logoutIntent = new Intent(this, LoginActivity.class);
-
-        // Clear back stack so Back doesn't return to Landing
-        logoutIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+        Intent logoutIntent = LoginActivity.createLogoutIntent(this);
         startActivity(logoutIntent);
         finish();
     }

--- a/app/src/main/java/edu/csumb/cst338/otterbots/rockpaperscissors/LoginActivity.java
+++ b/app/src/main/java/edu/csumb/cst338/otterbots/rockpaperscissors/LoginActivity.java
@@ -1,5 +1,6 @@
 package edu.csumb.cst338.otterbots.rockpaperscissors;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.widget.Toast;
@@ -39,18 +40,19 @@ public class LoginActivity extends AppCompatActivity {
             return;
         }
 
-        //TODO: Replace following code with real DB-based verification once repo is ready.
-        Intent intent = new Intent(LoginActivity.this, LandingActivity.class);
-        intent.putExtra(EXTRA_USERNAME, userName);
-
-        //TODO: Replace later with real DB isAdmin check.
+        //TODO: Replace hardcoded login + admin validation with real repo/DB verification once User DAO is implemented.
         boolean isAdmin = userName.equalsIgnoreCase("admin");
-        intent.putExtra(EXTRA_IS_ADMIN, isAdmin);
-
+        Intent intent = LandingActivity.createIntent(LoginActivity.this, userName, isAdmin);
         startActivity(intent);
     }
 
     private void toastMaker(String message) {
         Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
+    }
+
+    public static Intent createLogoutIntent(Context context) {
+        Intent logoutIntent = new Intent(context, LoginActivity.class);
+        logoutIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+        return logoutIntent;
     }
 }


### PR DESCRIPTION
This MR addresses @josh3io's suggestion about using intent factory methods for
navigation between `LoginActivity` and `LandingActivity`.

## Changes
- Added `LandingActivity.createIntent(Context context, String userName, boolean isAdmin)` to
  centralize creation of the Intent and extras.
- Updated `LoginActivity.verifyUser()` to use the factory method instead of building the Intent inline.
- Added `LoginActivity.createLogoutIntent(Context context)` and updated the logout flow in
  `LandingActivity` to use it.

## Notes
- No behavior changes; this is a pure refactor to reduce duplication and improve maintainability.

Closes #18