### PR TITLE
Adds the initial repository declaration and initialization to `LoginActivity`.

### DIFF
--- a/app/src/main/java/edu/csumb/cst338/otterbots/rockpaperscissors/LoginActivity.java
+++ b/app/src/main/java/edu/csumb/cst338/otterbots/rockpaperscissors/LoginActivity.java
@@ -6,6 +6,7 @@ import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import edu.csumb.cst338.otterbots.rockpaperscissors.database.entities.RockPaperScissorsRepository;
 import edu.csumb.cst338.otterbots.rockpaperscissors.databinding.ActivityLoginBinding;
 
 public class LoginActivity extends AppCompatActivity {
@@ -13,7 +14,7 @@ public class LoginActivity extends AppCompatActivity {
     public static final String EXTRA_IS_ADMIN = "isAdmin";
 
     private ActivityLoginBinding binding;
-    //TODO: Add rps repository declaration here, once repo is implemented.
+    private RockPaperScissorsRepository repository;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -21,7 +22,7 @@ public class LoginActivity extends AppCompatActivity {
         binding = ActivityLoginBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
-        //TODO: Add repository initialization here, once repo is implemented.
+        repository = RockPaperScissorsRepository.getRepository(getApplication());
 
         binding.loginButton.setOnClickListener(v -> verifyUser());
     }


### PR DESCRIPTION
### Changes
- Added `RockPaperScissorsRepository` field.
- Initialized repository in `onCreate()` using `getRepository(getApplication())`.

### Notes
- No behavior changes; this sets up the structure for future DB login once UserDao & repo methods are implemented.