### PR TITLE
refactor: extract login error messages into string resources

### DIFF
--- a/app/src/main/java/edu/csumb/cst338/otterbots/rockpaperscissors/LoginActivity.java
+++ b/app/src/main/java/edu/csumb/cst338/otterbots/rockpaperscissors/LoginActivity.java
@@ -29,13 +29,13 @@ public class LoginActivity extends AppCompatActivity {
     private void verifyUser() {
         String userName = binding.userNameLoginEditText.getText().toString().trim();
         if (userName.isEmpty()) {
-            toastMaker("Username should not be blank.");
+            toastMaker(getString(R.string.error_username_blank));
             return;
         }
 
         String userPassword = binding.passwordLoginEditText.getText().toString().trim();
         if (userPassword.isEmpty()) {
-            toastMaker("Password should not be blank.");
+            toastMaker(getString(R.string.error_password_blank));
             return;
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,5 +16,7 @@
     <string name="logout">Logout</string>
     <string name="welcome_admin_otterbot">Welcome\nAdmin OtterBot</string>
     <string name="add_user">Add User</string>
+    <string name="error_username_blank">Username should not be blank.</string>
+    <string name="error_password_blank">Password should not be blank.</string>
 
 </resources>


### PR DESCRIPTION
This MR extracts the hardcoded login error messages into `strings.xml` to follow
Android best practices and improve maintainability.

### Changes
- Added `error_username_blank` and `error_password_blank` to `strings.xml`.
- Updated `LoginActivity` to use `R.string.error_username_blank` and `R.string.error_password_blank`.

### Notes
- No behavior changes; this is a small UI cleanup refactor.