### PR TITLE
Fix: Add missing gameplay stats fields lost during merge conflict resolution

### DIFF
--- a/app/src/main/java/edu/csumb/cst338/otterbots/rockpaperscissors/GamePlayActivity.java
+++ b/app/src/main/java/edu/csumb/cst338/otterbots/rockpaperscissors/GamePlayActivity.java
@@ -23,6 +23,13 @@ public class GamePlayActivity extends AppCompatActivity {
     // Check if rps round ends in tie
     private boolean roundTie;
 
+    // fields for tracking user stats
+    private int wins = 0;
+    private int losses = 0;
+    private int ties = 0;
+    private int maxStreak = 0;
+    private int currentStreak = 0;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);


### PR DESCRIPTION
This PR restores the gameplay stats fields (wins, losses, ties, maxStreak, currentStreak) in GamePlayActivity that were dropped during prior merge conflict resolutions.

App was tested locally — gameplay works correctly and no runtime errors occur.

Safe to merge.