### PR TITLE
Add LandingActivity admin layout instrumentation test

### DIFF
--- a/app/src/androidTest/java/edu/csumb/cst338/otterbots/rockpaperscissors/LandingActivityTest.java
+++ b/app/src/androidTest/java/edu/csumb/cst338/otterbots/rockpaperscissors/LandingActivityTest.java
@@ -40,5 +40,29 @@ public class LandingActivityTest {
         }
     }
 
-    // TODO: Add tests for admin vs user layouts in a future MR.
+    @Test
+    public void whenIsAdminTrue_adminLayoutLoadsAndDisplaysUsername() {
+
+        // Arrange
+        Intent intent = new Intent(ApplicationProvider.getApplicationContext(), LandingActivity.class);
+
+        intent.putExtra(LandingActivity.EXTRA_USERNAME, "Anthony");
+        intent.putExtra(LandingActivity.EXTRA_USER_ID, -1); // Prevents DB observer from firing
+        intent.putExtra(EXTRA_IS_ADMIN, true);
+
+        // Act
+        try (ActivityScenario<LandingActivity> scenario = ActivityScenario.launch(intent)) {
+            scenario.onActivity(activity -> {
+                TextView titleView = activity.findViewById(R.id.titleLandingTextView);
+                assertNotNull(titleView);
+
+                String actualText = titleView.getText().toString();
+                assertTrue(actualText.contains("Anthony"));
+
+                // Admin layout ONLY - confirms correct layout was inflated
+                TextView addUserView = activity.findViewById(R.id.addUserTextView);
+                assertNotNull("Admin layout should include Add User view.", addUserView);
+            });
+        }
+    }
 }


### PR DESCRIPTION
This PR adds a new UI test for LandingActivity to validate the admin
layout path:

### Added Test
- **whenIsAdminTrue_adminLayoutLoadsAndDisplaysUsername**
  - Ensures correct layout inflation for admin users.
  - Confirms welcome text includes the admin username.
  - Confirms the admin-only "Add User" view exists.

### Why
- Expands test coverage of LandingActivity.
- Ensures role-based UI rendering behaves as expected.
- Completes the required Activity test coverage for this feature.

Closes issue #79
