### PR TITLE
Fix: Persist gameplay rounds to rpsRoundTable in GamePlayActivity

### DIFF
--- a/app/src/main/java/edu/csumb/cst338/otterbots/rockpaperscissors/GamePlayActivity.java
+++ b/app/src/main/java/edu/csumb/cst338/otterbots/rockpaperscissors/GamePlayActivity.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 
 import edu.csumb.cst338.otterbots.rockpaperscissors.api.RpsRandomNumberGenerator;
 import edu.csumb.cst338.otterbots.rockpaperscissors.database.entities.RockPaperScissorsRepository;
+import edu.csumb.cst338.otterbots.rockpaperscissors.database.entities.RpsRound;
 import edu.csumb.cst338.otterbots.rockpaperscissors.database.entities.UserStats;
 import edu.csumb.cst338.otterbots.rockpaperscissors.databinding.ActivityGamePlayBinding;
 
@@ -84,6 +85,28 @@ public class GamePlayActivity extends AppCompatActivity {
         updateDatabaseStats(outcome);
     }
 
+    private int convertChoiceToIndex(String choice) {
+        switch (choice) {
+            case "ROCK":
+                return 0;
+            case "PAPER":
+                return 1;
+            case "SCISSORS":
+                return 2;
+            default:
+                return -1;
+        }
+    }
+
+    private String outcomeToString(int outcome) {
+        switch (outcome) {
+            case UserStats.WIN: return "WIN";
+            case UserStats.TIE: return "TIE";
+            case UserStats.LOSE: return "LOSE";
+            default: return "UNKNOWN";
+        }
+    }
+
     private void updateDatabaseStats(int outcome) {
         Log.d(MainActivity.TAG,"update db stats with outcome "+outcome);
         RockPaperScissorsRepository repository = RockPaperScissorsRepository.getRepository(getApplication());
@@ -98,6 +121,15 @@ public class GamePlayActivity extends AppCompatActivity {
                 if (userStats == null) {
                     userStats = new UserStats(userId,0,0,0,0,0);
                 }
+
+                int userChoiceIndex = convertChoiceToIndex(userCurrentGuess);
+                int npcChoiceIndex = convertChoiceToIndex(npcCurrentGuess);
+                String resultString = outcomeToString(outcome);
+
+                RpsRound round = new RpsRound(userId, userChoiceIndex, npcChoiceIndex, resultString);
+                repository.insertRound(round);
+                Log.d(MainActivity.TAG, "Inserted round: " + round);
+
                 switch(outcome) {
                     case UserStats.WIN:
                         userStats.setCurrentStreak(userStats.getCurrentStreak() + 1);


### PR DESCRIPTION
### Summary
This PR fixes a missing feature in GamePlayActivity where gameplay rounds
were not being stored in the Room database. As a result, rpsRoundTable
remained empty during normal app usage despite existing DAO and repository
support.

### What Was Added
- Insert an RpsRound record after each round is played
- Map ROCK/PAPER/SCISSORS selections to numeric values (0,1,2)
- Convert outcome codes to readable result strings (WIN/TIE/LOSE)
- Added helper methods for cleaner conversion logic

### Why This Matters
- rpsRoundTable now correctly stores a full history of every users' rounds
- Aligns with ERD design and user stories involving persistent gameplay data
- Enables accurate stats tracking
- Prevents empty or inconsistent database state

### Verification
- Played multiple rounds in the emulator
- Confirmed rpsRoundTable shows new rows with correct userId, choices,
  outcome, and timestamp
- No changes required to other activities or repository components